### PR TITLE
Add Telegram notification on PR to review and merge on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Send telegram message on pull request to review
         if: github.event.pull_request.merged == false && github.event.action != 'closed'
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@2e9996f96e095a537aa4442da4af41ca7b594fba
         with:
           to: ${{ secrets.TELEGRAM_TO }}
           token: ${{ secrets.TELEGRAM_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
             Title: ${{ github.event.pull_request.title }}
       - name: Send telegram message on pull request merged to main
         if: github.event.pull_request.merged == true
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@2e9996f96e095a537aa4442da4af41ca7b594fba
         with:
           to: ${{ secrets.TELEGRAM_TO }}
           token: ${{ secrets.TELEGRAM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Pull request
+on:
+  pull_request:
+    types: [opened, closed, reopened, ready_for_review, review_requested]
+
+jobs:
+
+  notifications:
+    name: Telegram notifications
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send telegram message on pull request to review
+        if: github.event.pull_request.merged == false && github.event.action != 'closed'
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            ${{ github.repository }} repository
+
+            ${{ github.actor }} created new PR: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
+
+            Title: ${{ github.event.pull_request.title }}
+      - name: Send telegram message on pull request merged to main
+        if: github.event.pull_request.merged == true
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          format: markdown
+          message: |
+            ${{ github.repository }} repository
+            
+            ${{ github.actor }} merged PR: [#${{ github.event.number }}](${{ github.event.pull_request.html_url }})
+
+            Title: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
Using GH actions, add support to send Telegram notifications to a group when:

1.  PR is ready to review.
2.  PR was merged on main.

In order to make it work, the following tasks must be done:
- Create the following secrets on the project: 
  - TELEGRAM_TO: Contains the unique identifier for the chat group. 
  - TELEGRAM_TOKEN: TG authorization token.

  More information about the values: https://github.com/appleboy/telegram-action#secrets

- Add a TG bot on the chat to post the message.

- Merge the current PR configuration.

More information about the GH action used: https://github.com/marketplace/actions/telegram-notify