### PR TITLE
fix: @openzeppelin/contracts and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,27 @@
-.DS_STORE
+# directories
+yarn-error.log
+node_modules
+
+# Foundry files
+cache
+out-via-ir
+
+# files
+*.env
+*.log
+.DS_Store
+.pnp.*
+yarn-debug.log*
+yarn-error.log*
+
+# Keep related abi
+out/*/*
+
+# Keep the latest deployment only
+broadcast/*/*/*
+!broadcast/*/*/run-latest.json
+
+# Previous
 /target
-out/
-cache/
-out.json
 .idea
 .vscode
-.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
 	branch = v1.1.1
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/Openzeppelin/openzeppelin-contracts
+	branch = v4.8.0


### PR DESCRIPTION
- Added @openzeppelin/contracts submodule in .gitmodules

- Added .gitignore patterns from outdated [tooling](https://github.com/OpenProofOfHumanity/democratic-proof-of-humanity/tree/tooling) branch

Fixed error when trying to compile:
```
Error: 
Failed to resolve file: "/Users/nico/gh/democratic-proof-of-humanity/lib/openzeppelin-contracts/token/ERC20/IERC20.sol": No such file or directory (os error 2).
    --> "/Users/nico/gh/democratic-proof-of-humanity/src/ProofofHumanity.sol"
        "@openzeppelin/contracts/token/ERC20/IERC20.sol"
    Check configured remappings.
```